### PR TITLE
add initial password and name into migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ PORT=3000
 ADMIN_APP_HOST=localhost
 ADMIN_APP_PORT=5173
 JWT_SECRET=SomeRandomJWTString
+
+INITIAL_ADMIN_NAME=admin
+INITIAL_ADMIN_EMAIL=yourmail@example.com
+INITIAL_ADMIN_PASSWORD=SetPassword
 ```
 
 4. Run `npm run typeorm:migrate`

--- a/src/migrations/1716645261733-CreateUsers.ts
+++ b/src/migrations/1716645261733-CreateUsers.ts
@@ -9,11 +9,19 @@ export class CreateUsers1716645261733 implements MigrationInterface {
       `CREATE TABLE "users" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "name" character varying NOT NULL, "email" character varying NOT NULL, "password" character varying NOT NULL, "role" character varying NOT NULL DEFAULT 'user', "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_a3ffb1c0c8416b9fc6f907b7433" PRIMARY KEY ("id"))`,
     );
 
+    const { INITIAL_ADMIN_PASSWORD = "SetPassword" } = process.env;
+    const { INITIAL_ADMIN_EMAIL = "yourmail@example.com" } = process.env;
+    const { INITIAL_ADMIN_NAME = "admin" } = process.env;
+
     // Create an admin user
-    const hashedPassword = await encrypt.encryptpass("SetPassword");
+    const hashedPassword = await encrypt.encryptpass(INITIAL_ADMIN_PASSWORD);
     await queryRunner.query(
-      `INSERT INTO "users" ("name", "email", "password", "role") VALUES ('admin', 'youmail@example.com', $1, 'admin')`,
-      [hashedPassword],
+      `INSERT INTO "users" ("name", "email", "password", "role") VALUES ($1, $2, $3, 'admin')`,
+      [
+        INITIAL_ADMIN_NAME,
+        INITIAL_ADMIN_EMAIL,
+        hashedPassword
+      ],
     );
   }
 


### PR DESCRIPTION
In order to set a specific user and passwort when creating the volume within docker I added the ability to set the initial name, email and password with the environment variables. The default stays the same as before. (excluding typo)

```
INITIAL_ADMIN_NAME=admin
INITIAL_ADMIN_EMAIL=yourmail@example.com
INITIAL_ADMIN_PASSWORD=SetPassword
```